### PR TITLE
Fixed KomodoEdit#377

### DIFF
--- a/content/pref/pref-golang.js
+++ b/content/pref/pref-golang.js
@@ -8,6 +8,9 @@ var _bundle = Components.classes["@mozilla.org/intl/stringbundle;1"]
             .getService(Components.interfaces.nsIStringBundleService)
             .createBundle("chrome://komodo/locale/pref/pref-languages.properties");
 var log = ko.logging.getLogger("pref.pref-golang");
+var prefs = Components.classes["@activestate.com/koPrefService;1"].
+    getService(Components.interfaces.koIPrefService).prefs;
+var $ = require("ko/dom");
 //---- functions
 
 function OnPreferencePageOK(prefset)
@@ -162,6 +165,11 @@ function PrefGolang_checkVersion()
 
 function switchToEnvironmentTab() {
     var mainPrefWindow = parent;
+    var showAdvanced = prefs.getBoolean("prefs_show_advanced", false);
+    if (!showAdvanced) {
+        $("#toggleAdvanced", mainPrefWindow.document).attr("checked", "true")
+        mainPrefWindow.toggleAdvanced();
+    }
     mainPrefWindow.hPrefWindow.helper.selectRowById("environItem");
     mainPrefWindow.hPrefWindow.switchPage();
 }


### PR DESCRIPTION
Fixed that: https://github.com/Komodo/KomodoEdit/issues/377
If you click on `Environment Prefs` button but `Show Advanced` is unchecked, it become checked and Environment tab will open.